### PR TITLE
Fix alloy config for OTLP traces

### DIFF
--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -128,23 +128,25 @@ otelcol.processor.batch "default" {
   send_batch_max_size = 2048
 
   output {
-    traces = [otelcol.processor.resource.traces.input]
+    traces = [otelcol.processor.attributes.traces.input]
   }
 }
 
 // Ajout d'attributs de ressource pour améliorer l'observabilité
-otelcol.processor.resource "traces" {
-  attributes {
-    action = "upsert"
-    key = "deployment.environment"
-    value = "development"
-  }
-  
-  attributes {
-    action = "upsert"
-    key = "service.namespace"
-    value = "plant-care"
-  }
+otelcol.processor.attributes "traces" {
+  context = "resource"
+  actions = [
+    {
+      action = "upsert"
+      key    = "deployment.environment"
+      value  = "development"
+    },
+    {
+      action = "upsert"
+      key    = "service.namespace"
+      value  = "plant-care"
+    },
+  ]
 
   output {
     traces = [otelcol.exporter.otlp.tempo.input]


### PR DESCRIPTION
## Summary
- use `otelcol.processor.attributes` for adding resource attributes to traces

## Testing
- `bash run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68554e6a10dc832eae2f458772bc78b7