### PR TITLE
Fix Alloy config commas

### DIFF
--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -137,14 +137,14 @@ otelcol.processor.attributes "traces" {
   context = "resource"
   actions = [
     {
-      action = "upsert"
-      key    = "deployment.environment"
-      value  = "development"
+      action = "upsert",
+      key    = "deployment.environment",
+      value  = "development",
     },
     {
-      action = "upsert"
-      key    = "service.namespace"
-      value  = "plant-care"
+      action = "upsert",
+      key    = "service.namespace",
+      value  = "plant-care",
     },
   ]
 


### PR DESCRIPTION
## Summary
- fix missing commas in Alloy actions list

## Testing
- `bash ./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685554845478832e9e927246fe901f3a