### PR TITLE
Add basic route tests and hold PR label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,3 +223,14 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+  hold-pr:
+    name: Hold Pull Request
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: [tests, docker-build-test, security-scan]
+    steps:
+      - name: Add hold label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: hold

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -1,0 +1,57 @@
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.database import Base, get_db
+from app.main import app
+
+# Setup test environment
+os.environ["TESTING"] = "True"
+os.environ["ENCRYPTION_KEY"] = "test-encryption-key-for-testing"
+os.environ["ENCRYPTION_ENABLED"] = "True"
+
+TEST_DATABASE_URL = "sqlite:///./test_a_rosa_je.db"
+engine = create_engine(TEST_DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+# ensure photos dir exists
+os.makedirs("photos", exist_ok=True)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert "timestamp" in data
+
+
+def test_preflight_options():
+    response = client.options("/some/random/path")
+    assert response.status_code == 204
+    assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:5000"
+    assert "Access-Control-Allow-Methods" in response.headers
+
+
+def test_static_photo_serving():
+    filename = "test_main_photo.txt"
+    path = os.path.join("photos", filename)
+    with open(path, "w") as f:
+        f.write("hello")
+
+    response = client.get(f"/photos/{filename}")
+    assert response.status_code == 200
+    assert response.text == "hello"
+
+    os.remove(path)


### PR DESCRIPTION
## Summary
- test health check, options preflight and photo serving
- add hold job to CI workflow to label PRs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68555b752ab8832ebeed534d59418ada